### PR TITLE
Add configurable log level for transaction completion messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ sdlc.pro.spring.tx.board:
   storage: IN_MEMORY  # or REDIS
   enable-listener-log: true
   duration-buckets: [ 100, 500, 1000, 2000, 5000 ]
+  log-level: INFO     # TRACE | DEBUG | INFO | WARN | ERROR | OFF
 ```
 
 > `alarming-threshold`: Transaction duration (ms) above which the transaction will be highlighted

--- a/src/main/java/com/sdlc/pro/txboard/config/TxBoardProperties.java
+++ b/src/main/java/com/sdlc/pro/txboard/config/TxBoardProperties.java
@@ -12,6 +12,7 @@ public class TxBoardProperties {
     private StorageType storage = StorageType.IN_MEMORY;
     private boolean enableListenerLog = false;
     private List<Integer> durationBuckets = List.of(100, 500, 1000, 2000, 5000);
+    private LogLevel logLevel = LogLevel.INFO;
 
     public boolean isEnable() {
         return enable;
@@ -62,7 +63,19 @@ public class TxBoardProperties {
         this.durationBuckets = Collections.unmodifiableList(durationBuckets);
     }
 
+    public LogLevel getLogLevel() {
+        return logLevel;
+    }
+
+    public void setLogLevel(LogLevel logLevel) {
+        this.logLevel = logLevel;
+    }
+
     public enum StorageType {
         IN_MEMORY, REDIS
+    }
+
+    public enum LogLevel {
+        TRACE, DEBUG, INFO, WARN, ERROR, OFF
     }
 }

--- a/src/main/java/com/sdlc/pro/txboard/listener/TransactionPhaseListenerImpl.java
+++ b/src/main/java/com/sdlc/pro/txboard/listener/TransactionPhaseListenerImpl.java
@@ -119,12 +119,18 @@ public final class TransactionPhaseListenerImpl implements TransactionPhaseListe
 
     private void finish() {
         popCurrentTransactionInfo().ifPresent(txInfo -> {
-            // TODO: log the transaction info properly according to the configuration
-            log.info("Transaction [{}] consumed {}ms to completed with status {}",
-                    txInfo.getMethodName(),
-                    txInfo.getTransactionDuration(),
-                    txInfo.getStatus()
-            );
+            // Log the transaction according to configured level
+            String logMsg = "Transaction [{}] consumed {}ms to completed with status {}";
+            switch (txBoardProperties.getLogLevel()) {
+                case TRACE -> log.trace(logMsg, txInfo.getMethodName(), txInfo.getTransactionDuration(), txInfo.getStatus());
+                case DEBUG -> log.debug(logMsg, txInfo.getMethodName(), txInfo.getTransactionDuration(), txInfo.getStatus());
+                case INFO -> log.info(logMsg, txInfo.getMethodName(), txInfo.getTransactionDuration(), txInfo.getStatus());
+                case WARN -> log.warn(logMsg, txInfo.getMethodName(), txInfo.getTransactionDuration(), txInfo.getStatus());
+                case ERROR -> log.error(logMsg, txInfo.getMethodName(), txInfo.getTransactionDuration(), txInfo.getStatus());
+                case OFF -> {
+                    // do not log
+                }
+            }
 
             this.publishTransactionLogToListeners(txInfo);
         });

--- a/src/main/java/com/sdlc/pro/txboard/listener/TransactionPhaseListenerImpl.java
+++ b/src/main/java/com/sdlc/pro/txboard/listener/TransactionPhaseListenerImpl.java
@@ -119,17 +119,35 @@ public final class TransactionPhaseListenerImpl implements TransactionPhaseListe
 
     private void finish() {
         popCurrentTransactionInfo().ifPresent(txInfo -> {
-            // Log the transaction according to configured level
-            String logMsg = "Transaction [{}] consumed {}ms to completed with status {}";
+            TransactionLog txLog = txInfo.toTransactionLog();
+            String logMsg = String.format(
+                    """
+                            [TX-Board] Transaction Completed:
+                              • ID: %s
+                              • Method: %s
+                              • Status: %s
+                              • Duration: %s ms
+                              • Connections Acquired: %s
+                              • Queries Executed: %s
+                              • Started At: %s
+                              • Ended At: %s""",
+                    txLog.getTxId(),
+                    txLog.getMethod(),
+                    txLog.getStatus(),
+                    txLog.getDuration(),
+                    txLog.getConnectionAcquisitionCount(),
+                    txLog.getTotalQueryCount(),
+                    txLog.getStartTime(),
+                    txLog.getEndTime()
+            );
+
             switch (txBoardProperties.getLogLevel()) {
-                case TRACE -> log.trace(logMsg, txInfo.getMethodName(), txInfo.getTransactionDuration(), txInfo.getStatus());
-                case DEBUG -> log.debug(logMsg, txInfo.getMethodName(), txInfo.getTransactionDuration(), txInfo.getStatus());
-                case INFO -> log.info(logMsg, txInfo.getMethodName(), txInfo.getTransactionDuration(), txInfo.getStatus());
-                case WARN -> log.warn(logMsg, txInfo.getMethodName(), txInfo.getTransactionDuration(), txInfo.getStatus());
-                case ERROR -> log.error(logMsg, txInfo.getMethodName(), txInfo.getTransactionDuration(), txInfo.getStatus());
-                case OFF -> {
-                    // do not log
-                }
+                case TRACE -> log.trace(logMsg);
+                case DEBUG -> log.debug(logMsg);
+                case INFO -> log.info(logMsg);
+                case WARN -> log.warn(logMsg);
+                case ERROR -> log.error(logMsg);
+                case OFF -> {}
             }
 
             this.publishTransactionLogToListeners(txInfo);

--- a/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -35,6 +35,12 @@
       "name": "sdlc.pro.spring.tx.board.duration-buckets",
       "type": "java.util.List<java.lang.Integer>",
       "description": "List of duration buckets (in ms) for distribution analysis."
+    },
+    {
+      "name": "sdlc.pro.spring.tx.board.log-level",
+      "type": "com.sdlc.pro.txboard.config.TxBoardProperties.LogLevel",
+      "defaultValue": "INFO",
+      "description": "Log level for transaction completion message. Options: TRACE, DEBUG, INFO, WARN, ERROR, OFF."
     }
   ]
 }


### PR DESCRIPTION
This is the PR for issue #35 & #31

- Introduced `logLevel` property in `TxBoardProperties` with enum levels.
- Updated `TransactionPhaseListenerImpl` to respect the configured log level.
- Extended README and metadata definitions to document the new property.
- Enhance transaction completion logs with detailed context
