### PR TITLE
Add configurable transaction logging with SIMPLE and DETAILS modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,72 @@ This dashboard provides a real-time view of transaction activity including filte
 * **IN\_MEMORY** (default): Simple, thread-safe `List` with in-memory counters
 * **REDIS** (planned): Store and distribute logs across instances (not-implemented)
 
+## Configurable transaction logging
+
+Spring Tx Board emits a completion log when a transaction ends. You can choose between two logging modes via the property below:
+
+- `sdlc.pro.spring.tx.board.log-type=SIMPLE` (default)
+- `sdlc.pro.spring.tx.board.log-type=DETAILS`
+
+**Health-based severity**
+- Healthy transaction (<= alarming thresholds) logs at INFO level.
+- Unhealthy transaction (exceeds transaction duration or connection occupied-time thresholds) logs at WARN level.
+
+**Example configuration (YAML)**
+
+```yaml
+sdlc.pro.spring.tx.board:
+  enable: true
+  # select logging style
+  log-type: DETAILS   # SIMPLE | DETAILS
+  # thresholds used to determine INFO vs WARN
+  alarming-threshold:
+    transaction: 1000   # ms
+    connection: 1000    # ms
+```
+
+### Examples
+
+**SIMPLE** (healthy -> INFO)
+```
+Transaction [UserService.createUser] took 152 ms, Status: COMMITTED
+```
+
+**SIMPLE** (unhealthy -> WARN)
+```
+Transaction [UserService.createUser] took 2150 ms, Status: COMMITTED, Connections: 3, Queries: 12
+```
+
+**DETAILS** (healthy -> INFO)
+```
+[TX-Board] Transaction Completed:
+  • ID: 123
+  • Method: UserService.createUser
+  • Status: COMMITTED
+  • Duration: 152 ms
+  • Connections Acquired: 2
+  • Queries Executed: 5
+  • Started At: 2025-08-17T10:15:30.123Z
+  • Ended At: 2025-08-17T10:15:30.275Z
+```
+
+**DETAILS** (with inner transactions, unhealthy -> WARN)
+```
+[TX-Board] Transaction Completed:
+  • ID: 789
+  • Method: CheckoutService.checkout
+  • Status: COMMITTED
+  • Duration: 2200 ms
+  • Connections Acquired: 4
+  • Queries Executed: 18
+  • Started At: 2025-08-17T10:15:30.123Z
+  • Ended At: 2025-08-17T10:15:32.323Z
+  • Inner Transactions:
+      - InventoryService.reserveStock (450 ms, COMMITTED)
+      - PaymentService.charge (1200 ms, COMMITTED)
+      - EmailService.sendReceipt (120 ms, COMMITTED)
+```
+
 ## Developer Usage
 
 Just annotate your service methods with `@Transactional` or use `TransactionTemplate`, and Spring Tx Board will

--- a/src/main/java/com/sdlc/pro/txboard/config/TxBoardProperties.java
+++ b/src/main/java/com/sdlc/pro/txboard/config/TxBoardProperties.java
@@ -12,6 +12,7 @@ public class TxBoardProperties {
     private StorageType storage = StorageType.IN_MEMORY;
     private boolean enableListenerLog = false;
     private List<Integer> durationBuckets = List.of(100, 500, 1000, 2000, 5000);
+    private LogType logType = LogType.SIMPLE;
 
     public boolean isEnable() {
         return enable;
@@ -62,8 +63,20 @@ public class TxBoardProperties {
         this.durationBuckets = Collections.unmodifiableList(durationBuckets);
     }
 
+    public LogType getLogType() {
+        return logType;
+    }
+
+    public void setLogType(LogType logType) {
+        this.logType = logType == null ? LogType.SIMPLE : logType;
+    }
+
     public enum StorageType {
         IN_MEMORY, REDIS
+    }
+
+    public enum LogType {
+        SIMPLE, DETAILS
     }
 
     public static class AlarmingThreshold {

--- a/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -41,6 +41,12 @@
       "type": "java.lang.Long",
       "defaultValue": 1000,
       "description": "Duration threshold (in ms) for alarming high connection occupied time."
+    },
+    {
+      "name": "sdlc.pro.spring.tx.board.log-type",
+      "type": "com.sdlc.pro.txboard.config.TxBoardProperties.LogType",
+      "defaultValue": "SIMPLE",
+      "description": "Logging mode for transaction completion logs. Options: SIMPLE, DETAILS."
     }
   ]
 }


### PR DESCRIPTION
### Description

This pull request introduces configurable transaction logging with two modes: SIMPLE (compact) and DETAILS (verbose).  
- Added a `logType` property to allow mode selection.  
- Adjusted log severity dynamically based on transaction health status.  
- Updated documentation and metadata to reflect the new logging configurations.  

These changes enhance clarity and debugging flexibility by providing adaptive log details. 

Closing #31 

---
## Configurable transaction logging

Spring Tx Board emits a completion log when a transaction ends. You can choose between two logging modes via the property below:

- `sdlc.pro.spring.tx.board.log-type=SIMPLE` (default)
- `sdlc.pro.spring.tx.board.log-type=DETAILS`

**Health-based severity**
- Healthy transaction (<= alarming thresholds) logs at INFO level.
- Unhealthy transaction (exceeds transaction duration or connection occupied-time thresholds) logs at WARN level.

**Example configuration (YAML)**

```yaml
sdlc.pro.spring.tx.board:
  enable: true
  # select logging style
  log-type: DETAILS   # SIMPLE | DETAILS
  # thresholds used to determine INFO vs WARN
  alarming-threshold:
    transaction: 1000   # ms
    connection: 1000    # ms
```

### Examples

**SIMPLE** (healthy -> INFO)
```
Transaction [UserService.createUser] took 152 ms, Status: COMMITTED
```

**SIMPLE** (unhealthy -> WARN)
```
Transaction [UserService.createUser] took 2150 ms, Status: COMMITTED, Connections: 3, Queries: 12
```

**DETAILS** (healthy -> INFO)
```
[TX-Board] Transaction Completed:
  • ID: 123
  • Method: UserService.createUser
  • Status: COMMITTED
  • Duration: 152 ms
  • Connections Acquired: 2
  • Queries Executed: 5
  • Started At: 2025-08-17T10:15:30.123Z
  • Ended At: 2025-08-17T10:15:30.275Z
```

**DETAILS** (with inner transactions, unhealthy -> WARN)
```
[TX-Board] Transaction Completed:
  • ID: 789
  • Method: CheckoutService.checkout
  • Status: COMMITTED
  • Duration: 2200 ms
  • Connections Acquired: 4
  • Queries Executed: 18
  • Started At: 2025-08-17T10:15:30.123Z
  • Ended At: 2025-08-17T10:15:32.323Z
  • Inner Transactions:
      - InventoryService.reserveStock (450 ms, COMMITTED)
      - PaymentService.charge (1200 ms, COMMITTED)
      - EmailService.sendReceipt (120 ms, COMMITTED)
```