### PR TITLE
Update .gitignore to properly exclude .idea files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,10 @@
+HELP.md
 target/
-!.mvn/wrapper/maven-wrapper.jar
+.mvn/wrapper/maven-wrapper.jar
 !**/src/main/**/target/
 !**/src/test/**/target/
 
-### IntelliJ IDEA ###
-.idea/modules.xml
-.idea/jarRepositories.xml
-.idea/compiler.xml
-.idea/libraries/
-*.iws
-*.iml
-*.ipr
-
-### Eclipse ###
+### STS ###
 .apt_generated
 .classpath
 .factorypath
@@ -20,6 +12,12 @@ target/
 .settings
 .springBeans
 .sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
 
 ### NetBeans ###
 /nbproject/private/
@@ -33,6 +31,3 @@ build/
 
 ### VS Code ###
 .vscode/
-
-### Mac OS ###
-.DS_Store


### PR DESCRIPTION
**Description**
This PR updates the `.gitignore` file to properly exclude `.idea` and other IDE-specific files. The previous configuration only ignored selective subfolders, which could result in committing unnecessary project-specific metadata.

**Changes**

* Replaced the existing `.gitignore` entries with the default template from [[start.spring.io](https://start.spring.io/)](https://start.spring.io)
* Ensures `.idea` and related IDE files are fully excluded from version control

**Closes Issue:** #58 