### PR TITLE
Add Spring Boot 2.x Compatibility Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ yarn-debug.log
 yarn-error.log
 .pnp/
 .pnp.js
+/.idea/

--- a/pom.xml
+++ b/pom.xml
@@ -5,10 +5,10 @@
 
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.sdlc.pro</groupId>
-    <artifactId>spring-tx-board</artifactId>
+    <artifactId>spring-tx-board-boot2</artifactId>
     <version>1.6.0</version>
     <packaging>jar</packaging>
-    <name>Spring Transaction Board</name>
+    <name>Spring Transaction Board (Spring Boot 2.4.x / Java 8)</name>
     <description>Auto-configurable Spring transaction monitoring library</description>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,8 @@
     <description>Auto-configurable Spring transaction monitoring library</description>
 
     <properties>
-        <java.version>17</java.version>
-        <spring.boot.version>3.2.0</spring.boot.version>
+        <java.version>1.8</java.version>
+        <spring.boot.version>2.4.0</spring.boot.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/src/main/java/com/sdlc/pro/txboard/autoconfigure/BeanPostProcessorAutoConfiguration.java
+++ b/src/main/java/com/sdlc/pro/txboard/autoconfigure/BeanPostProcessorAutoConfiguration.java
@@ -5,35 +5,36 @@ import com.sdlc.pro.txboard.proxy.PlatformTransactionManagerProxy;
 import com.sdlc.pro.txboard.listener.TransactionPhaseListener;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanPostProcessor;
-import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.transaction.PlatformTransactionManager;
 
 import javax.sql.DataSource;
 
-@AutoConfiguration(
-        value = "com.sdlc.pro.txboard.autoconfigure.BeanPostProcessorAutoConfiguration",
-        before = SpringTxBoardAutoConfiguration.class
-)
+@Configuration
+@AutoConfigureBefore(SpringTxBoardAutoConfiguration.class)
 @ConditionalOnProperty(prefix = "sdlc.pro.spring.tx.board", name = "enable", havingValue = "true", matchIfMissing = true)
 public class BeanPostProcessorAutoConfiguration implements BeanPostProcessor, ApplicationContextAware {
     private ApplicationContext applicationContext;
 
     @Override
     public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
-        if (bean instanceof DataSource dataSource) {
+        if (bean instanceof DataSource) {
+            DataSource dataSource = (DataSource) bean;
             TransactionPhaseListener transactionPhaseListener = this.applicationContext.getBean(TransactionPhaseListener.class);
             return new DataSourceProxy(dataSource, transactionPhaseListener);
         }
 
-        if (bean instanceof PlatformTransactionManager transactionManager) {
+        if (bean instanceof PlatformTransactionManager) {
+            PlatformTransactionManager transactionManager = (PlatformTransactionManager) bean;
             TransactionPhaseListener transactionPhaseListener = this.applicationContext.getBean(TransactionPhaseListener.class);
             return new PlatformTransactionManagerProxy(transactionManager, transactionPhaseListener);
         }
 
-        return BeanPostProcessor.super.postProcessAfterInitialization(bean, beanName);
+        return bean;
     }
 
     @Override

--- a/src/main/java/com/sdlc/pro/txboard/autoconfigure/SpringTxBoardAutoConfiguration.java
+++ b/src/main/java/com/sdlc/pro/txboard/autoconfigure/SpringTxBoardAutoConfiguration.java
@@ -5,20 +5,19 @@ import com.sdlc.pro.txboard.config.TxBoardProperties;
 import com.sdlc.pro.txboard.listener.TransactionLogListener;
 import com.sdlc.pro.txboard.listener.TransactionPhaseListener;
 import com.sdlc.pro.txboard.listener.TransactionPhaseListenerImpl;
-import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
 
 import java.util.List;
 
-@AutoConfiguration(
-        value = "com.sdlc.pro.txboard.autoconfigure.SpringTxBoardAutoConfiguration",
-        after = BeanPostProcessorAutoConfiguration.class
-)
+@Configuration
+@AutoConfigureAfter(BeanPostProcessorAutoConfiguration.class)
 @ConditionalOnClass(PlatformTransactionManager.class)
 @EnableConfigurationProperties(TxBoardProperties.class)
 @Import({SpringTxBoardWebConfiguration.class})

--- a/src/main/java/com/sdlc/pro/txboard/config/TxBoardProperties.java
+++ b/src/main/java/com/sdlc/pro/txboard/config/TxBoardProperties.java
@@ -2,6 +2,7 @@ package com.sdlc.pro.txboard.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -11,7 +12,7 @@ public class TxBoardProperties {
     private AlarmingThreshold alarmingThreshold = new AlarmingThreshold();
     private StorageType storage = StorageType.IN_MEMORY;
     private boolean enableListenerLog = false;
-    private List<Integer> durationBuckets = List.of(100, 500, 1000, 2000, 5000);
+    private List<Integer> durationBuckets = Arrays.asList(100, 500, 1000, 2000, 5000);
     private LogType logType = LogType.SIMPLE;
 
     public boolean isEnable() {

--- a/src/main/java/com/sdlc/pro/txboard/domain/FilterNode.java
+++ b/src/main/java/com/sdlc/pro/txboard/domain/FilterNode.java
@@ -1,6 +1,6 @@
 package com.sdlc.pro.txboard.domain;
 
-public sealed interface FilterNode permits Filter, FilterGroup, FilterNode.UnFilter {
+public interface FilterNode {
     FilterNode UNFILTERED = new UnFilter();
 
     final class UnFilter implements FilterNode {}

--- a/src/main/java/com/sdlc/pro/txboard/domain/Sort.java
+++ b/src/main/java/com/sdlc/pro/txboard/domain/Sort.java
@@ -17,7 +17,7 @@ public class Sort {
     private Sort(String property, Direction direction) {
         Objects.requireNonNull(property);
         Objects.requireNonNull(direction);
-        if (property.isBlank()) {
+        if (property.trim().isEmpty()) {
             throw new IllegalArgumentException("The sort property must not be blank");
         }
         this.property = property;

--- a/src/main/java/com/sdlc/pro/txboard/dto/TransactionChart.java
+++ b/src/main/java/com/sdlc/pro/txboard/dto/TransactionChart.java
@@ -4,5 +4,12 @@ import com.sdlc.pro.txboard.model.DurationDistribution;
 
 import java.util.List;
 
-public record TransactionChart(List<DurationDistribution> durationDistribution) {
+public class TransactionChart {
+    private final List<DurationDistribution> durationDistribution;
+
+    public TransactionChart(List<DurationDistribution> durationDistribution) {
+        this.durationDistribution = durationDistribution;
+    }
+
+    public List<DurationDistribution> getDurationDistribution() { return durationDistribution; }
 }

--- a/src/main/java/com/sdlc/pro/txboard/dto/TransactionMetrics.java
+++ b/src/main/java/com/sdlc/pro/txboard/dto/TransactionMetrics.java
@@ -1,8 +1,27 @@
 package com.sdlc.pro.txboard.dto;
 
-public record TransactionMetrics(long totalTransactions,
-                                 long committedCount,
-                                 long rolledBackCount,
-                                 double successRate,
-                                 double avgDuration) {
+public class TransactionMetrics {
+    private final long totalTransactions;
+    private final long committedCount;
+    private final long rolledBackCount;
+    private final double successRate;
+    private final double avgDuration;
+
+    public TransactionMetrics(long totalTransactions,
+                              long committedCount,
+                              long rolledBackCount,
+                              double successRate,
+                              double avgDuration) {
+        this.totalTransactions = totalTransactions;
+        this.committedCount = committedCount;
+        this.rolledBackCount = rolledBackCount;
+        this.successRate = successRate;
+        this.avgDuration = avgDuration;
+    }
+
+    public long getTotalTransactions() { return totalTransactions; }
+    public long getCommittedCount() { return committedCount; }
+    public long getRolledBackCount() { return rolledBackCount; }
+    public double getSuccessRate() { return successRate; }
+    public double getAvgDuration() { return avgDuration; }
 }

--- a/src/main/java/com/sdlc/pro/txboard/handler/TransactionChartHttpHandler.java
+++ b/src/main/java/com/sdlc/pro/txboard/handler/TransactionChartHttpHandler.java
@@ -4,9 +4,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sdlc.pro.txboard.dto.TransactionChart;
 import com.sdlc.pro.txboard.model.DurationDistribution;
 import com.sdlc.pro.txboard.repository.TransactionLogRepository;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import org.springframework.http.MediaType;
 import org.springframework.web.HttpRequestHandler;
 

--- a/src/main/java/com/sdlc/pro/txboard/handler/TransactionLogsHttpHandler.java
+++ b/src/main/java/com/sdlc/pro/txboard/handler/TransactionLogsHttpHandler.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sdlc.pro.txboard.enums.TransactionPhaseStatus;
 import com.sdlc.pro.txboard.domain.*;
 import com.sdlc.pro.txboard.repository.TransactionLogRepository;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import org.springframework.http.MediaType;
 import org.springframework.web.HttpRequestHandler;
 
@@ -60,9 +60,9 @@ public class TransactionLogsHttpHandler implements HttpRequestHandler {
     public static FilterNode buildFilter(String search, String status) {
         List<FilterNode> filters = new ArrayList<>();
 
-        if (search != null && !search.isBlank()) {
+        if (search != null && !search.trim().isEmpty()) {
             filters.add(FilterGroup.of(
-                    List.of(
+                    java.util.Arrays.asList(
                             Filter.of("method", search, Filter.Operator.CONTAINS),
                             Filter.of("thread", search, Filter.Operator.CONTAINS)
                     ),
@@ -70,7 +70,7 @@ public class TransactionLogsHttpHandler implements HttpRequestHandler {
             ));
         }
 
-        if (status != null && !status.isBlank()) {
+        if (status != null && !status.trim().isEmpty()) {
             try {
                 filters.add(Filter.of("status", TransactionPhaseStatus.valueOf(status), Filter.Operator.EQUALS));
             } catch (IllegalArgumentException e) {

--- a/src/main/java/com/sdlc/pro/txboard/handler/TransactionMetricsHttpHandler.java
+++ b/src/main/java/com/sdlc/pro/txboard/handler/TransactionMetricsHttpHandler.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sdlc.pro.txboard.enums.TransactionPhaseStatus;
 import com.sdlc.pro.txboard.dto.TransactionMetrics;
 import com.sdlc.pro.txboard.repository.TransactionLogRepository;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import org.springframework.http.MediaType;
 import org.springframework.web.HttpRequestHandler;
 

--- a/src/main/java/com/sdlc/pro/txboard/listener/TransactionLogListener.java
+++ b/src/main/java/com/sdlc/pro/txboard/listener/TransactionLogListener.java
@@ -2,6 +2,6 @@ package com.sdlc.pro.txboard.listener;
 
 import com.sdlc.pro.txboard.model.TransactionLog;
 
-public sealed interface TransactionLogListener permits TransactionLogPersistenceListener {
+public interface TransactionLogListener {
     void listen(TransactionLog transactionLog);
 }

--- a/src/main/java/com/sdlc/pro/txboard/listener/TransactionPhaseListener.java
+++ b/src/main/java/com/sdlc/pro/txboard/listener/TransactionPhaseListener.java
@@ -1,9 +1,8 @@
 package com.sdlc.pro.txboard.listener;
 
 import org.springframework.transaction.TransactionDefinition;
-import org.springframework.transaction.TransactionStatus;
 
-public sealed interface TransactionPhaseListener permits TransactionPhaseListenerImpl {
+public interface TransactionPhaseListener {
 
     default void beforeBegin(TransactionDefinition definition) {
     }

--- a/src/main/java/com/sdlc/pro/txboard/model/ConnectionSummary.java
+++ b/src/main/java/com/sdlc/pro/txboard/model/ConnectionSummary.java
@@ -1,4 +1,17 @@
 package com.sdlc.pro.txboard.model;
 
-public record ConnectionSummary(int acquisitionCount, int alarmingConnectionCount, long occupiedTime) {
+public class ConnectionSummary {
+    private final int acquisitionCount;
+    private final int alarmingConnectionCount;
+    private final long occupiedTime;
+
+    public ConnectionSummary(int acquisitionCount, int alarmingConnectionCount, long occupiedTime) {
+        this.acquisitionCount = acquisitionCount;
+        this.alarmingConnectionCount = alarmingConnectionCount;
+        this.occupiedTime = occupiedTime;
+    }
+
+    public int getAcquisitionCount() { return acquisitionCount; }
+    public int getAlarmingConnectionCount() { return alarmingConnectionCount; }
+    public long getOccupiedTime() { return occupiedTime; }
 }

--- a/src/main/java/com/sdlc/pro/txboard/model/DurationDistribution.java
+++ b/src/main/java/com/sdlc/pro/txboard/model/DurationDistribution.java
@@ -1,4 +1,14 @@
 package com.sdlc.pro.txboard.model;
 
-public record DurationDistribution(DurationRange range, long count) {
+public class DurationDistribution {
+    private final DurationRange range;
+    private final long count;
+
+    public DurationDistribution(DurationRange range, long count) {
+        this.range = range;
+        this.count = count;
+    }
+
+    public DurationRange getRange() { return range; }
+    public long getCount() { return count; }
 }

--- a/src/main/java/com/sdlc/pro/txboard/model/DurationRange.java
+++ b/src/main/java/com/sdlc/pro/txboard/model/DurationRange.java
@@ -1,8 +1,16 @@
 package com.sdlc.pro.txboard.model;
 
-public record DurationRange(long minMillis, long maxMillis) {
+public class DurationRange {
+    private final long minMillis;
+    private final long maxMillis;
+
+    public DurationRange(long minMillis, long maxMillis) {
+        this.minMillis = minMillis;
+        this.maxMillis = maxMillis;
+    }
+
     public static DurationRange of(long minMillis, long maxMillis) {
-        return new DurationRange(minMillis,  maxMillis);
+        return new DurationRange(minMillis, maxMillis);
     }
 
     /**
@@ -12,4 +20,7 @@ public record DurationRange(long minMillis, long maxMillis) {
     public boolean matches(long millis) {
         return millis >= minMillis && millis < maxMillis;
     }
+
+    public long getMinMillis() { return minMillis; }
+    public long getMaxMillis() { return maxMillis; }
 }

--- a/src/main/java/com/sdlc/pro/txboard/model/TransactionLog.java
+++ b/src/main/java/com/sdlc/pro/txboard/model/TransactionLog.java
@@ -10,6 +10,8 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 
+import static java.util.Collections.emptyList;
+
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class TransactionLog implements Serializable {
     private final Integer txId;
@@ -48,7 +50,7 @@ public class TransactionLog implements Serializable {
         this.events = events;
         this.alarmingTransaction = this.duration > txAlarmingThreshold;
         this.havingAlarmingConnection = this.connectionSummary != null ?
-                this.connectionSummary.occupiedTime() > conAlarmingThreshold : null;
+                this.connectionSummary.getOccupiedTime() > conAlarmingThreshold : null;
     }
 
     public Integer getTxId() {
@@ -92,11 +94,11 @@ public class TransactionLog implements Serializable {
     }
 
     public List<TransactionLog> getChild() {
-        return this.child == null ? List.of() : this.child;
+        return this.child == null ? emptyList() : this.child;
     }
 
     public List<String> getExecutedQuires() {
-        return this.executedQuires == null ? List.of() : this.executedQuires;
+        return this.executedQuires == null ? emptyList() : this.executedQuires;
     }
 
     public List<TransactionEvent> getEvents() {

--- a/src/main/java/com/sdlc/pro/txboard/repository/TransactionLogRepository.java
+++ b/src/main/java/com/sdlc/pro/txboard/repository/TransactionLogRepository.java
@@ -8,7 +8,7 @@ import com.sdlc.pro.txboard.model.TransactionLog;
 
 import java.util.List;
 
-public sealed interface TransactionLogRepository permits InMemoryTransactionLogRepository, RedisTransactionLogRepository {
+public interface TransactionLogRepository {
     void save(TransactionLog transactionLog);
     List<TransactionLog> findAll();
     long count();

--- a/src/main/java/com/sdlc/pro/txboard/util/FilterPredicateFactory.java
+++ b/src/main/java/com/sdlc/pro/txboard/util/FilterPredicateFactory.java
@@ -11,10 +11,10 @@ import java.util.function.Predicate;
 public final class FilterPredicateFactory {
 
     public static <T> Predicate<T> buildPredicate(FilterNode node) {
-        if (node instanceof Filter filter) {
-            return buildPredicateFromFilter(filter);
-        } else if (node instanceof FilterGroup group) {
-            return buildGroupPredicate(group);
+        if (node instanceof Filter) {
+            return buildPredicateFromFilter((Filter) node);
+        } else if (node instanceof FilterGroup) {
+            return buildGroupPredicate((FilterGroup) node);
         }
         return (Predicate<T>) t -> true;
     }
@@ -27,17 +27,28 @@ public final class FilterPredicateFactory {
 
                 if (fieldValue == null) return false;
 
-                return switch (filter.getOperator()) {
-                    case EQUALS -> fieldValue.equals(targetValue);
-                    case NOT_EQUALS -> !fieldValue.equals(targetValue);
-                    case GREATER_THAN -> compare(fieldValue, targetValue) > 0;
-                    case GREATER_THAN_OR_EQUALS -> compare(fieldValue, targetValue) >= 0;
-                    case LESS_THAN -> compare(fieldValue, targetValue) < 0;
-                    case LESS_THAN_OR_EQUALS -> compare(fieldValue, targetValue) <= 0;
-                    case CONTAINS -> contains(fieldValue, targetValue);
-                    case STARTS_WITH -> startsWith(fieldValue, targetValue);
-                    case ENDS_WITH -> endsWith(fieldValue, targetValue);
-                };
+                switch (filter.getOperator()) {
+                    case EQUALS:
+                        return fieldValue.equals(targetValue);
+                    case NOT_EQUALS:
+                        return !fieldValue.equals(targetValue);
+                    case GREATER_THAN:
+                        return compare(fieldValue, targetValue) > 0;
+                    case GREATER_THAN_OR_EQUALS:
+                        return compare(fieldValue, targetValue) >= 0;
+                    case LESS_THAN:
+                        return compare(fieldValue, targetValue) < 0;
+                    case LESS_THAN_OR_EQUALS:
+                        return compare(fieldValue, targetValue) <= 0;
+                    case CONTAINS:
+                        return contains(fieldValue, targetValue);
+                    case STARTS_WITH:
+                        return startsWith(fieldValue, targetValue);
+                    case ENDS_WITH:
+                        return endsWith(fieldValue, targetValue);
+                    default:
+                        return false;
+                }
             } catch (Exception e) {
                 return false;
             }
@@ -75,21 +86,32 @@ public final class FilterPredicateFactory {
     }
 
     private static boolean contains(Object fieldValue, Object value) {
-        if (fieldValue instanceof String s && value instanceof String v) {
+        if (fieldValue instanceof String && value instanceof String) {
+            String s = ((String) fieldValue);
+            String v = ((String) value);
             return s.toLowerCase().contains(v.toLowerCase());
-        } else if (fieldValue instanceof Collection<?> c) {
+        } else if (fieldValue instanceof Collection) {
+            Collection<?> c = (Collection<?>) fieldValue;
             return c.contains(value);
         }
         return false;
     }
 
     private static boolean startsWith(Object fieldValue, Object value) {
-        return (fieldValue instanceof String s && value instanceof String v) &&
-                s.toLowerCase().startsWith(v.toLowerCase());
+        if (fieldValue instanceof String && value instanceof String) {
+            String s = (String) fieldValue;
+            String v = (String) value;
+            return s.toLowerCase().startsWith(v.toLowerCase());
+        }
+        return false;
     }
 
     private static boolean endsWith(Object fieldValue, Object value) {
-        return (fieldValue instanceof String s && value instanceof String v) &&
-                s.toLowerCase().endsWith(v.toLowerCase());
+        if (fieldValue instanceof String && value instanceof String) {
+            String s = (String) fieldValue;
+            String v = (String) value;
+            return s.toLowerCase().endsWith(v.toLowerCase());
+        }
+        return false;
     }
 }

--- a/src/main/java/com/sdlc/pro/txboard/util/SortUtils.java
+++ b/src/main/java/com/sdlc/pro/txboard/util/SortUtils.java
@@ -6,6 +6,8 @@ import java.lang.reflect.Method;
 import java.util.Comparator;
 import java.util.List;
 
+import static java.util.stream.Collectors.toList;
+
 public class SortUtils {
 
     public static <T> List<T> sort(List<T> data, Sort sort) {
@@ -15,7 +17,7 @@ public class SortUtils {
             Comparator<T> comparator = buildComparator(sort);
             return data.stream()
                     .sorted(comparator)
-                    .toList();
+                    .collect(toList());
         } catch (Exception e) {
             return data; // fail-safe: return unsorted
         }
@@ -52,11 +54,6 @@ public class SortUtils {
         String methodName = "get" + Character.toUpperCase(fieldName.toCharArray()[0]) + fieldName.substring(1);
 
         try {
-            try {
-                if (clazz.isRecord()) {
-                    return clazz.getDeclaredMethod(fieldName);
-                }
-            } catch (NoSuchMethodException ignored) {}
             return clazz.getDeclaredMethod(methodName);
         } catch (NoSuchMethodException ignored) {
             throw new NoSuchMethodException("Method " + methodName + " not found on " + clazz);

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,3 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  com.sdlc.pro.txboard.autoconfigure.SpringTxBoardAutoConfiguration
-  com.sdlc.pro.txboard.autoconfigure.BeanPostProcessorAutoConfiguration
+com.sdlc.pro.txboard.autoconfigure.SpringTxBoardAutoConfiguration,\
+com.sdlc.pro.txboard.autoconfigure.BeanPostProcessorAutoConfiguration


### PR DESCRIPTION
### Description

This pull request introduces compatibility support for Spring Boot 2.x and JDK 8 by making the following changes:

- Converted Java records to standard classes to align with older JDK support.
- Replaced modern `.toList()` APIs with `Collectors.toList()` for Java 8 compatibility.
- Updated property validations by reverting from `String.isBlank()` to `String.trim().isEmpty()`.
- Simplified interfaces by removing the use of sealed keywords and hierarchy restrictions unsupported in JDK 8.
- Downgraded Spring Boot version to 2.4.0 and Java version to 1.8 in the `pom.xml` file.
- Reworked constructs reliant on JDK 17 features with equivalents compatible with JDK 8.
- Applied minor adjustments for consistent API usage across the codebase.

These changes ensure compatibility with environments still reliant on older Java and Spring Boot versions.

### Notes

* Documentation updates are intentionally omitted from this PR.
* A separate PR will be created for the `master` branch to address documentation.
* Relevant changes may be cherry-picked into the `master-boot2` branch if necessary.

### Request

* Reviewers who are working with **Spring Boot 2 applications** are kindly requested to test this update and confirm its functionality.

Closing #52 