### PR TITLE
feature/STB-30: integrate Spring TX Board with Spring Boot Actuator

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,57 @@ If your application includes Spring Web, a minimal built-in UI is accessible at:
 
 This dashboard provides a real-time view of transaction activity including filtering, status, execution time, and more.
 
+## Spring Boot Actuator Integration
+
+When Spring Boot Actuator is available, TX Board automatically exposes additional monitoring endpoints:
+
+### Custom Actuator Endpoint
+
+Access comprehensive transaction metrics at:
+> http://localhost:8080/actuator/txboard
+
+Returns JSON with transaction counts, duration metrics, connection statistics, and duration distributions.
+
+### Micrometer Metrics
+
+TX Board automatically registers metrics with Micrometer when available:
+
+- `txboard.transactions.total` - Total number of transactions
+- `txboard.transactions.committed` - Number of committed transactions  
+- `txboard.transactions.rolled_back` - Number of rolled back transactions
+- `txboard.transactions.errored` - Number of errored transactions
+- `txboard.transactions.alarming` - Number of slow transactions
+- `txboard.transactions.duration.total` - Total duration (ms)
+- `txboard.transactions.duration.average` - Average duration (ms)
+- `txboard.connections.acquisitions` - Total connection acquisitions
+- `txboard.connections.occupied_time.total` - Total connection time (ms)
+- `txboard.connections.occupied_time.average` - Average connection time (ms)
+- `txboard.connections.alarming` - Number of long-held connections
+
+Access these at:
+> http://localhost:8080/actuator/metrics/<trx metrics>
+
+Example:
+> http://localhost:8080/actuator/metrics/txboard.transactions.total
+
+### Configuration
+
+To enable actuator, add the following to your `application.yml` or `application.properties`:
+
+```yaml
+sdlc.pro.spring.tx.board.actuator.enable: true # Enable custom actuator endpoint
+management.endpoints.web.exposure.include: metrics,txboard # Enable actuator and metrics endpoint
+```
+
+**Requirements**: Add `spring-boot-starter-actuator` dependency for actuator integration.
+
+```xml
+<dependency>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-actuator</artifactId>
+</dependency>
+```
+
 ## Storage Options
 
 * **IN\_MEMORY** (default): Simple, thread-safe `List` with in-memory counters

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,11 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/src/main/java/com/sdlc/pro/txboard/actuator/TxBoardActuatorEndpoint.java
+++ b/src/main/java/com/sdlc/pro/txboard/actuator/TxBoardActuatorEndpoint.java
@@ -1,0 +1,56 @@
+package com.sdlc.pro.txboard.actuator;
+
+import com.sdlc.pro.txboard.model.DurationDistribution;
+import com.sdlc.pro.txboard.model.TransactionSummary;
+import com.sdlc.pro.txboard.repository.TransactionLogRepository;
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Endpoint(id = "txboard")
+public class TxBoardActuatorEndpoint {
+    private final TransactionLogRepository transactionLogRepository;
+
+    public TxBoardActuatorEndpoint(TransactionLogRepository transactionLogRepository) {
+        this.transactionLogRepository = transactionLogRepository;
+    }
+
+    @ReadOperation
+    public Map<String, Object> txBoardInfo() {
+        TransactionSummary summary = transactionLogRepository.getTransactionSummary();
+        List<DurationDistribution> distributions = transactionLogRepository.getDurationDistributions();
+
+        Map<String, Object> result = new HashMap<>();
+        
+        // Transaction counts
+        Map<String, Object> transactions = new HashMap<>();
+        transactions.put("total", summary.getTotalTransaction());
+        transactions.put("committed", summary.getCommittedCount());
+        transactions.put("rolledBack", summary.getRolledBackCount());
+        transactions.put("errored", summary.getErroredCount());
+        transactions.put("alarming", summary.getAlarmingCount());
+        result.put("transactions", transactions);
+
+        // Duration metrics
+        Map<String, Object> duration = new HashMap<>();
+        duration.put("total", summary.getTotalDuration());
+        duration.put("average", summary.getAverageDuration());
+        result.put("duration", duration);
+
+        // Connection metrics
+        Map<String, Object> connections = new HashMap<>();
+        connections.put("acquisitions", summary.getConnectionAcquisitionCount());
+        connections.put("totalOccupiedTime", summary.getTotalConnectionOccupiedTime());
+        connections.put("averageOccupiedTime", summary.getAverageConnectionOccupiedTime());
+        connections.put("alarming", summary.getAlarmingConnectionCount());
+        result.put("connections", connections);
+
+        // Duration distribution
+        result.put("durationDistribution", distributions);
+
+        return result;
+    }
+}

--- a/src/main/java/com/sdlc/pro/txboard/actuator/TxBoardMicrometerMetrics.java
+++ b/src/main/java/com/sdlc/pro/txboard/actuator/TxBoardMicrometerMetrics.java
@@ -1,0 +1,73 @@
+package com.sdlc.pro.txboard.actuator;
+
+import org.springframework.beans.factory.InitializingBean;
+
+import com.sdlc.pro.txboard.model.TransactionSummary;
+import com.sdlc.pro.txboard.repository.TransactionLogRepository;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+
+public class TxBoardMicrometerMetrics implements InitializingBean {
+    private final MeterRegistry meterRegistry;
+    private final TransactionLogRepository transactionLogRepository;
+
+    public TxBoardMicrometerMetrics(MeterRegistry meterRegistry, TransactionLogRepository transactionLogRepository) {
+        this.meterRegistry = meterRegistry;
+        this.transactionLogRepository = transactionLogRepository;
+    }
+
+    @Override
+    public void afterPropertiesSet() {
+        // Transaction count metrics
+        Gauge.builder("txboard.transactions.total", () -> getTransactionSummary().getTotalTransaction())
+                .description("Total number of transactions processed")
+                .register(meterRegistry);
+
+        Gauge.builder("txboard.transactions.committed", () -> getTransactionSummary().getCommittedCount())
+                .description("Number of committed transactions")
+                .register(meterRegistry);
+
+        Gauge.builder("txboard.transactions.rolled_back", () -> getTransactionSummary().getRolledBackCount())
+                .description("Number of rolled back transactions")
+                .register(meterRegistry);
+
+        Gauge.builder("txboard.transactions.errored", () -> getTransactionSummary().getErroredCount())
+                .description("Number of errored transactions")
+                .register(meterRegistry);
+
+        Gauge.builder("txboard.transactions.alarming", () -> getTransactionSummary().getAlarmingCount())
+                .description("Number of alarming transactions (slow)")
+                .register(meterRegistry);
+
+        // Duration metrics
+        Gauge.builder("txboard.transactions.duration.total", () -> getTransactionSummary().getTotalDuration())
+                .description("Total duration of all transactions in milliseconds")
+                .register(meterRegistry);
+
+        Gauge.builder("txboard.transactions.duration.average", () -> getTransactionSummary().getAverageDuration())
+                .description("Average transaction duration in milliseconds")
+                .register(meterRegistry);
+
+        // Connection metrics
+        Gauge.builder("txboard.connections.acquisitions", () -> getTransactionSummary().getConnectionAcquisitionCount())
+                .description("Total number of connection acquisitions")
+                .register(meterRegistry);
+
+        Gauge.builder("txboard.connections.occupied_time.total", () -> getTransactionSummary().getTotalConnectionOccupiedTime())
+                .description("Total connection occupied time in milliseconds")
+                .register(meterRegistry);
+
+        Gauge.builder("txboard.connections.occupied_time.average", () -> getTransactionSummary().getAverageConnectionOccupiedTime())
+                .description("Average connection occupied time in milliseconds")
+                .register(meterRegistry);
+
+        Gauge.builder("txboard.connections.alarming", () -> getTransactionSummary().getAlarmingConnectionCount())
+                .description("Number of alarming connections (long-held)")
+                .register(meterRegistry);
+    }
+
+    private TransactionSummary getTransactionSummary() {
+        return transactionLogRepository.getTransactionSummary();
+    }
+}

--- a/src/main/java/com/sdlc/pro/txboard/autoconfigure/SpringTxBoardAutoConfiguration.java
+++ b/src/main/java/com/sdlc/pro/txboard/autoconfigure/SpringTxBoardAutoConfiguration.java
@@ -7,6 +7,8 @@ import com.sdlc.pro.txboard.config.TxBoardProperties;
 import com.sdlc.pro.txboard.listener.TransactionLogListener;
 import com.sdlc.pro.txboard.listener.TransactionPhaseListener;
 import com.sdlc.pro.txboard.listener.TransactionPhaseListenerImpl;
+
+import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -19,7 +21,10 @@ import java.util.List;
 
 @AutoConfiguration(
         value = "com.sdlc.pro.txboard.autoconfigure.SpringTxBoardAutoConfiguration",
-        after = BeanPostProcessorAutoConfiguration.class
+        after = {
+            BeanPostProcessorAutoConfiguration.class,
+            CompositeMeterRegistryAutoConfiguration.class
+        }
 )
 @ConditionalOnClass(PlatformTransactionManager.class)
 @EnableConfigurationProperties(TxBoardProperties.class)

--- a/src/main/java/com/sdlc/pro/txboard/autoconfigure/SpringTxBoardAutoConfiguration.java
+++ b/src/main/java/com/sdlc/pro/txboard/autoconfigure/SpringTxBoardAutoConfiguration.java
@@ -1,6 +1,7 @@
 package com.sdlc.pro.txboard.autoconfigure;
 
 import com.sdlc.pro.txboard.config.SpringTxBoardActuatorConfiguration;
+import com.sdlc.pro.txboard.config.SpringTxBoardMicrometerConfiguration;
 import com.sdlc.pro.txboard.config.SpringTxBoardWebConfiguration;
 import com.sdlc.pro.txboard.config.TxBoardProperties;
 import com.sdlc.pro.txboard.listener.TransactionLogListener;
@@ -22,7 +23,7 @@ import java.util.List;
 )
 @ConditionalOnClass(PlatformTransactionManager.class)
 @EnableConfigurationProperties(TxBoardProperties.class)
-@Import({SpringTxBoardWebConfiguration.class, SpringTxBoardActuatorConfiguration.class})
+@Import({SpringTxBoardWebConfiguration.class, SpringTxBoardActuatorConfiguration.class, SpringTxBoardMicrometerConfiguration.class})
 @ConditionalOnProperty(prefix = "sdlc.pro.spring.tx.board", name = "enable", havingValue = "true", matchIfMissing = true)
 public class SpringTxBoardAutoConfiguration {
 

--- a/src/main/java/com/sdlc/pro/txboard/autoconfigure/SpringTxBoardAutoConfiguration.java
+++ b/src/main/java/com/sdlc/pro/txboard/autoconfigure/SpringTxBoardAutoConfiguration.java
@@ -1,5 +1,6 @@
 package com.sdlc.pro.txboard.autoconfigure;
 
+import com.sdlc.pro.txboard.config.SpringTxBoardActuatorConfiguration;
 import com.sdlc.pro.txboard.config.SpringTxBoardWebConfiguration;
 import com.sdlc.pro.txboard.config.TxBoardProperties;
 import com.sdlc.pro.txboard.listener.TransactionLogListener;
@@ -21,7 +22,7 @@ import java.util.List;
 )
 @ConditionalOnClass(PlatformTransactionManager.class)
 @EnableConfigurationProperties(TxBoardProperties.class)
-@Import({SpringTxBoardWebConfiguration.class})
+@Import({SpringTxBoardWebConfiguration.class, SpringTxBoardActuatorConfiguration.class})
 @ConditionalOnProperty(prefix = "sdlc.pro.spring.tx.board", name = "enable", havingValue = "true", matchIfMissing = true)
 public class SpringTxBoardAutoConfiguration {
 

--- a/src/main/java/com/sdlc/pro/txboard/config/SpringTxBoardActuatorConfiguration.java
+++ b/src/main/java/com/sdlc/pro/txboard/config/SpringTxBoardActuatorConfiguration.java
@@ -1,0 +1,33 @@
+package com.sdlc.pro.txboard.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import com.sdlc.pro.txboard.actuator.TxBoardActuatorEndpoint;
+import com.sdlc.pro.txboard.repository.TransactionLogRepository;
+
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnClass({PlatformTransactionManager.class, Endpoint.class})
+@ConditionalOnProperty(
+    name = {
+        "sdlc.pro.spring.tx.board.enable",
+        "sdlc.pro.spring.tx.board.actuator.enable"
+    },
+    havingValue = "true",
+    matchIfMissing = true
+)
+public class SpringTxBoardActuatorConfiguration {
+    private static final Logger log = LoggerFactory.getLogger(SpringTxBoardActuatorConfiguration.class);
+
+    @Bean("sdlcProTxBoardActuatorEndpoint")
+    public TxBoardActuatorEndpoint txBoardActuatorEndpoint(TransactionLogRepository transactionLogRepository) {
+        log.info("TX Board Actuator endpoint enabled at /actuator/txboard");
+        return new TxBoardActuatorEndpoint(transactionLogRepository);
+    }
+}

--- a/src/main/java/com/sdlc/pro/txboard/config/SpringTxBoardActuatorConfiguration.java
+++ b/src/main/java/com/sdlc/pro/txboard/config/SpringTxBoardActuatorConfiguration.java
@@ -13,15 +13,8 @@ import com.sdlc.pro.txboard.actuator.TxBoardActuatorEndpoint;
 import com.sdlc.pro.txboard.repository.TransactionLogRepository;
 
 @Configuration(proxyBeanMethods = false)
-@ConditionalOnClass({PlatformTransactionManager.class, Endpoint.class})
-@ConditionalOnProperty(
-    name = {
-        "sdlc.pro.spring.tx.board.enable",
-        "sdlc.pro.spring.tx.board.actuator.enable"
-    },
-    havingValue = "true",
-    matchIfMissing = true
-)
+@ConditionalOnClass({ PlatformTransactionManager.class, Endpoint.class })
+@ConditionalOnProperty(name = "sdlc.pro.spring.tx.board.actuator.enable", havingValue = "true", matchIfMissing = true)
 public class SpringTxBoardActuatorConfiguration {
     private static final Logger log = LoggerFactory.getLogger(SpringTxBoardActuatorConfiguration.class);
 

--- a/src/main/java/com/sdlc/pro/txboard/config/SpringTxBoardMicrometerConfiguration.java
+++ b/src/main/java/com/sdlc/pro/txboard/config/SpringTxBoardMicrometerConfiguration.java
@@ -1,0 +1,37 @@
+package com.sdlc.pro.txboard.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import com.sdlc.pro.txboard.actuator.TxBoardMicrometerMetrics;
+import com.sdlc.pro.txboard.repository.TransactionLogRepository;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnClass({PlatformTransactionManager.class, MeterRegistry.class})
+@ConditionalOnProperty(
+    name = {
+        "sdlc.pro.spring.tx.board.enable",
+        "sdlc.pro.spring.tx.board.actuator.enable"
+    },
+    havingValue = "true",
+    matchIfMissing = true
+)
+public class SpringTxBoardMicrometerConfiguration {
+    private static final Logger log = LoggerFactory.getLogger(SpringTxBoardMicrometerConfiguration.class);
+
+    @Bean("sdlcProTxBoardMicrometerMetrics")
+    @ConditionalOnBean(MeterRegistry.class)
+    public TxBoardMicrometerMetrics txBoardMicrometerMetrics(MeterRegistry meterRegistry, 
+                                                             TransactionLogRepository transactionLogRepository) {
+        log.info("TX Board Micrometer metrics enabled at /actuator/metrics/txboard.*");
+        return new TxBoardMicrometerMetrics(meterRegistry, transactionLogRepository);
+    }
+}

--- a/src/main/java/com/sdlc/pro/txboard/config/SpringTxBoardMicrometerConfiguration.java
+++ b/src/main/java/com/sdlc/pro/txboard/config/SpringTxBoardMicrometerConfiguration.java
@@ -15,22 +15,16 @@ import com.sdlc.pro.txboard.repository.TransactionLogRepository;
 import io.micrometer.core.instrument.MeterRegistry;
 
 @Configuration(proxyBeanMethods = false)
-@ConditionalOnClass({PlatformTransactionManager.class, MeterRegistry.class})
-@ConditionalOnProperty(
-    name = {
-        "sdlc.pro.spring.tx.board.enable",
-        "sdlc.pro.spring.tx.board.actuator.enable"
-    },
-    havingValue = "true",
-    matchIfMissing = true
-)
+@ConditionalOnClass({ PlatformTransactionManager.class, MeterRegistry.class })
+@ConditionalOnProperty(name = "sdlc.pro.spring.tx.board.actuator.enable", havingValue = "true", matchIfMissing = true)
 public class SpringTxBoardMicrometerConfiguration {
     private static final Logger log = LoggerFactory.getLogger(SpringTxBoardMicrometerConfiguration.class);
 
     @Bean("sdlcProTxBoardMicrometerMetrics")
     @ConditionalOnBean(MeterRegistry.class)
-    public TxBoardMicrometerMetrics txBoardMicrometerMetrics(MeterRegistry meterRegistry, 
-                                                             TransactionLogRepository transactionLogRepository) {
+    public TxBoardMicrometerMetrics txBoardMicrometerMetrics(MeterRegistry meterRegistry,
+            TransactionLogRepository transactionLogRepository) {
+
         log.info("TX Board Micrometer metrics enabled at /actuator/metrics/txboard.*");
         return new TxBoardMicrometerMetrics(meterRegistry, transactionLogRepository);
     }

--- a/src/main/java/com/sdlc/pro/txboard/config/TxBoardProperties.java
+++ b/src/main/java/com/sdlc/pro/txboard/config/TxBoardProperties.java
@@ -13,6 +13,7 @@ public class TxBoardProperties {
     private boolean enableListenerLog = false;
     private List<Integer> durationBuckets = List.of(100, 500, 1000, 2000, 5000);
     private LogType logType = LogType.SIMPLE;
+    private Actuator actuator = new Actuator();
 
     public boolean isEnable() {
         return enable;
@@ -71,6 +72,14 @@ public class TxBoardProperties {
         this.logType = logType == null ? LogType.SIMPLE : logType;
     }
 
+    public Actuator getActuator() {
+        return actuator;
+    }
+
+    public void setActuator(Actuator actuator) {
+        this.actuator = actuator;
+    }
+
     public enum StorageType {
         IN_MEMORY, REDIS
     }
@@ -97,6 +106,18 @@ public class TxBoardProperties {
 
         public void setConnection(long connection) {
             this.connection = connection;
+        }
+    }
+
+    public static class Actuator {
+        private boolean enable = true;
+
+        public boolean isEnable() {
+            return enable;
+        }
+
+        public void setEnable(boolean enable) {
+            this.enable = enable;
         }
     }
 }

--- a/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -47,6 +47,12 @@
       "type": "com.sdlc.pro.txboard.config.TxBoardProperties.LogType",
       "defaultValue": "SIMPLE",
       "description": "Logging mode for transaction completion logs. Options: SIMPLE, DETAILS."
+    },
+    {
+      "name": "sdlc.pro.spring.tx.board.actuator.enable",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enable or disable the actuator integration"
     }
   ]
 }


### PR DESCRIPTION
## Description

This pull request adds Spring Boot Actuator integration to TX Board, enabling advanced monitoring features through custom endpoints and Micrometer metrics. The changes introduce new configuration options, update dependencies, and provide documentation for using these features.

- closes issue #30 

**Spring Boot Actuator Integration**

* Added a new custom actuator endpoint (`TxBoardActuatorEndpoint`) to expose comprehensive transaction metrics at `/actuator/txboard`, including transaction counts, duration metrics, connection statistics, and duration distributions. [[1]](diffhunk://#diff-337afaace32462b8e50ff62d3f9f1abcc0454ef550ff65a218339a8e459ee90bR1-R56) [[2]](diffhunk://#diff-c814e3451e6b345352940a64c20fcc53cc4022cb4c31e041c0d769885232616bR1-R26)
* Implemented Micrometer metrics registration (`TxBoardMicrometerMetrics`) for transaction and connection statistics, accessible via `/actuator/metrics/txboard.*`. [[1]](diffhunk://#diff-e0ff09a4cfbb2a7ee4715f5dd8475dc423e4173b15156836844bfb4cad0db1caR1-R73) [[2]](diffhunk://#diff-4ec69650b744febaac7c3ec0796d0a585b069975c8446dae1aefd8b9ea5150c2R1-R31)

**Configuration and Dependency Updates**

* Updated `SpringTxBoardAutoConfiguration` to conditionally import actuator and metrics configurations, allowing seamless integration when Spring Boot Actuator is present. [[1]](diffhunk://#diff-536da52f2c46b5109adf7a413a508168e9f4fbda25a583dc86ad751f56effb3bR3-R11) [[2]](diffhunk://#diff-536da52f2c46b5109adf7a413a508168e9f4fbda25a583dc86ad751f56effb3bL20-R31)
* Added the `spring-boot-starter-actuator` dependency to `pom.xml` to enable actuator features.
* Enhanced `TxBoardProperties` and metadata to support enabling/disabling actuator integration via configuration (`sdlc.pro.spring.tx.board.actuator.enable`). [[1]](diffhunk://#diff-04c4f331ed9e5c874dc2665b0a3b8ab813f92a4ff6cfd672db13acfb85f5cf49R16) [[2]](diffhunk://#diff-04c4f331ed9e5c874dc2665b0a3b8ab813f92a4ff6cfd672db13acfb85f5cf49R75-R82) [[3]](diffhunk://#diff-04c4f331ed9e5c874dc2665b0a3b8ab813f92a4ff6cfd672db13acfb85f5cf49R111-R122) [[4]](diffhunk://#diff-c29ba0031f38b1c90af2492e22f9719fd8c7c1ff0bb56a407fba79d4f9934f9eR50-R55)

**Documentation**

* Updated `README.md` with instructions on actuator endpoints, available metrics, configuration steps, and requirements for enabling actuator integration.

## Data Exposed
The data exposed via actuator are
```json
{
  "duration": {
    "average": 0,
    "total": 0
  },
  "durationDistribution": [
    {
      "range": {
        "minMillis": 0,
        "maxMillis": 100
      },
      "count": 0
    },
    {
      "range": {
        "minMillis": 100,
        "maxMillis": 500
      },
      "count": 0
    },
    {
      "range": {
        "minMillis": 500,
        "maxMillis": 1000
      },
      "count": 0
    },
    {
      "range": {
        "minMillis": 1000,
        "maxMillis": 2000
      },
      "count": 0
    },
    {
      "range": {
        "minMillis": 2000,
        "maxMillis": 5000
      },
      "count": 0
    }
  ],
  "transactions": {
    "total": 0,
    "committed": 0,
    "alarming": 0,
    "rolledBack": 0,
    "errored": 0
  },
  "connections": {
    "alarming": 0,
    "averageOccupiedTime": 0,
    "totalOccupiedTime": 0,
    "acquisitions": 0
  }
}
```

and the metrics exposed via micrometer are
```
  "txboard.connections.acquisitions",
  "txboard.connections.alarming",
  "txboard.connections.occupied_time.average",
  "txboard.connections.occupied_time.total",
  "txboard.transactions.alarming",
  "txboard.transactions.committed",
  "txboard.transactions.duration.average",
  "txboard.transactions.duration.total",
  "txboard.transactions.errored",
  "txboard.transactions.rolled_back",
  "txboard.transactions.total"
  ```

## Sanity Checks
The actuator or micrometer enpoints are not created when the `sdlc.pro.spring.tx.board.actuator.enable` is set to false, or when there is no actuator in classpath. 

## Possible issues
When the variable `sdlc.pro.spring.tx.board.actuator.enable` is set to true, but the variable `management.endpoints.web.exposure.include` doesn't include txboard and metrics, the endpoints are not exposed via http but the beans are still created. If this is a problem, please suggest possible way to fix it.