### PR TITLE
Update .gitignore to fully exclude IDE and build files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,13 +4,23 @@ target/
 !**/src/test/**/target/
 
 ### IntelliJ IDEA ###
-.idea/modules.xml
-.idea/jarRepositories.xml
-.idea/compiler.xml
-.idea/libraries/
+.idea
 *.iws
 *.iml
 *.ipr
+
+# optionally,ignore workspace-specific files
+.idea/workspace.xml
+.idea/tasks.xml
+.idea/dictionaries/
+.idea/vcs.xml
+.idea/scopes/
+.idea/caches/
+.idea/libraries/
+.idea/modules.xml
+.idea/jarRepositories.xml
+.idea/compiler.xml
+
 out/
 
 ### Eclipse ###


### PR DESCRIPTION
- Updated .gitignore based on Spring Initializr defaults.
- Fully ignores IntelliJ IDEA (.idea/, *.iml, *.ipr, *.iws) and optional workspace files.
- Ensures Eclipse, NetBeans, VS Code, node_modules, and OS-specific files (.DS_Store, Thumbs.db) are ignored.
- Prevents accidental commits of IDE-specific or build-related files.
- Verified that no tracked IDE files remain in the repository.
