### PR TITLE
Docs: reference community demo for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,14 @@ public class OrderService {
 
 No additional annotations or API calls required.
 
+## Using the demo project for development
+
+You can use the community demo project at `https://github.com/jamilxt/tx-board-banking-demo.git` to develop and test
+changes to this library quickly. The demo is a small Spring Boot application that integrates `spring-tx-board` so you can
+see the UI, logs, and transaction traces locally.
+
+Follow the demo project's `README.md` for setup and usage instructions: https://github.com/jamilxt/tx-board-banking-demo.git
+
 ## Utilities
 
 ### Duration Distribution


### PR DESCRIPTION
Keep README concise by adding a short "Using the demo project for development" section that points to the community demo repository.
The section preserves the provided paragraph describing the demo and adds a single-line pointer to the demo project's README for setup and usage.

Changes:
- Updated `README.md`: added/updated the "Using the demo project for development" section to reference https://github.com/jamilxt/tx-board-banking-demo.git

Why:
- Avoids duplicating demo setup instructions in two places.
- Directs users to the demo project's authoritative README for current setup and run instructions.
- Keeps this library's README focused and minimal.

Verification:
- Edited `README.md` in the repository and verified the file change.
- No code or behavior changes were made.