### PR TITLE
Stb 154/add datasourceproxytest boot2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,13 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
-            <optional>true</optional>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.28.2</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/src/test/java/com/sdlc/pro/txboard/proxy/DataSourceProxyTest.java
+++ b/src/test/java/com/sdlc/pro/txboard/proxy/DataSourceProxyTest.java
@@ -1,0 +1,58 @@
+package com.sdlc.pro.txboard.proxy;
+
+import com.sdlc.pro.txboard.listener.TransactionPhaseListener;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class DataSourceProxyTest {
+
+    @Mock
+    private DataSource dataSource;
+
+    @Mock
+    private Connection connection;
+
+    @Mock
+    private TransactionPhaseListener transactionPhaseListener;
+
+    private DataSourceProxy dataSourceProxy;
+
+    @BeforeEach
+    void setUp() throws SQLException {
+        lenient().when(dataSource.getConnection()).thenReturn(connection);
+        lenient().when(dataSource.getConnection("user", "pass")).thenReturn(connection);
+        dataSourceProxy = new DataSourceProxy(dataSource, transactionPhaseListener);
+    }
+
+    @Test
+    void testGetConnection_DelegatesAndTriggersListener() throws Exception {
+        Connection result = dataSourceProxy.getConnection();
+
+        verify(dataSource).getConnection();
+        verify(transactionPhaseListener).afterAcquiredConnection();
+
+        result.close();
+        verify(transactionPhaseListener).afterCloseConnection();
+    }
+
+    @Test
+    void testGetConnectionWithCredentials_DelegatesAndTriggersListener() throws Exception {
+        Connection result = dataSourceProxy.getConnection("user", "pass");
+
+        verify(dataSource).getConnection("user", "pass");
+        verify(transactionPhaseListener).afterAcquiredConnection();
+
+        result.close();
+        verify(transactionPhaseListener).afterCloseConnection();
+    }
+}


### PR DESCRIPTION
Related Issue

Fixes https://github.com/Mamun-Al-Babu-Shikder/spring-tx-board/issues/154

Summary

This PR backports the DataSourceProxyTest class from the master branch to the master-boot2 branch to ensure consistent test coverage for Spring Boot 2 / Java 8 environments.
The test verifies proper delegation of getConnection() methods and ensures that transaction phase listener methods are triggered as expected.

Changes Made

Added DataSourceProxyTest under src/test/java/com/sdlc/pro/txboard/proxy/

Verified delegation for:

getConnection()

getConnection(String, String)

Ensured TransactionPhaseListener.afterAcquiredConnection() and afterCloseConnection() are triggered correctly

Used lenient() stubbing for Java 8 compatibility to avoid unnecessary stubbing errors

Testing

 mvn clean install passes

 mvn test -Dtest=DataSourceProxyTest passes

 Verified both test cases execute successfully and listener methods are invoked as expected

Notes for Reviewers

Please review the use of lenient() stubbing — this is intentional to ensure compatibility with the strict Mockito settings used in this branch.

The tests follow the structure from the master branch but are adapted for Java 8 / Spring Boot 2.

Checklist

 I have merged the latest changes from upstream master-boot2.

 I have added necessary documentation (if appropriate).

 I have added tests that prove my fix is effective and my feature works.

 All tests pass locally.